### PR TITLE
Update snowplow internship link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [Open Summer of Code](http://2017.summerofcode.be/) | Yes** |
 | [FOSSASIA Internship Programme](https://blog.fossasia.org/fossasia-internship-program-2018/) | No |
 | [Hyperledger Internship Program](https://wiki.hyperledger.org/internship/program_overview) | Yes |
-| [Snowplow](https://snowplowanalytics.com/company/careers/?gh_jid=1107068) | Yes |
+| [Snowplow](https://snowplowanalytics.com/blog/recruitment/) | Yes |
 | [ICFOSS](https://icfoss.in/event/invitation-for-interns-0) | No |
 | [ERPNext Summer of Code](https://erpnext.org/esoc) | Yes |
 | [Redox Summer Of Code](https://www.redox-os.org/rsoc/)| Yes |


### PR DESCRIPTION
fixes issue #78 
As stated in the issue #78, Snowplow does not have a single page for its open source internship, however the current [link](https://snowplowanalytics.com/company/careers/?gh_jid=1107068) does not reflect recent information on the internship.
Snowplow has a blog [section ](https://snowplowanalytics.com/blog/recruitment/)with only information on the open source internships, and I think that will be more helpful to intending interns.

Snowplow prefers to [announce ](https://discourse.snowplowanalytics.com/t/snowplow-internship-program-one-off-or-regular/1293) her internships on [hackernews](https://news.ycombinator.com/item?id=15388728)

